### PR TITLE
Adding custom line lenght step

### DIFF
--- a/lib/steps_indicator.dart
+++ b/lib/steps_indicator.dart
@@ -21,6 +21,7 @@ class StepsIndicator extends StatelessWidget {
   final Widget doneStepWidget;
   final Widget unselectedStepWidget;
   final Widget selectedStepWidget;
+  final List<StepsIndicatorCustomLine> lineLengthCustomStep;
 
   const StepsIndicator(
       {this.selectedStep = 0,
@@ -40,7 +41,8 @@ class StepsIndicator extends StatelessWidget {
       this.selectedStepBorderSize = 1,
       this.doneStepWidget,
       this.unselectedStepWidget,
-      this.selectedStepWidget});
+      this.selectedStepWidget,
+      this.lineLengthCustomStep});
 
   @override
   Widget build(BuildContext context) {
@@ -72,21 +74,21 @@ class StepsIndicator extends StatelessWidget {
           ? Row(
               children: <Widget>[
                 stepSelectedWidget(),
-                selectedStep == nbSteps ? stepLineDoneWidget() : Container(),
-                i != nbSteps - 1 ? stepLineUndoneWidget() : Container()
+                selectedStep == nbSteps ? stepLineDoneWidget(i) : Container(),
+                i != nbSteps - 1 ? stepLineUndoneWidget(i) : Container()
               ],
             )
           : selectedStep > i
               ? Row(
                   children: <Widget>[
                     stepDoneWidget(),
-                    i < nbSteps - 1 ? stepLineDoneWidget() : Container(),
+                    i < nbSteps - 1 ? stepLineDoneWidget(i) : Container(),
                   ],
                 )
               : Row(
                   children: <Widget>[
                     stepUnselectedWidget(),
-                    i != nbSteps - 1 ? stepLineUndoneWidget() : Container()
+                    i != nbSteps - 1 ? stepLineUndoneWidget(i) : Container()
                   ],
                 ));
     } else {
@@ -95,21 +97,21 @@ class StepsIndicator extends StatelessWidget {
           ? Column(
               children: <Widget>[
                 stepSelectedWidget(),
-                selectedStep == nbSteps ? stepLineDoneWidget() : Container(),
-                i != nbSteps - 1 ? stepLineUndoneWidget() : Container()
+                selectedStep == nbSteps ? stepLineDoneWidget(i) : Container(),
+                i != nbSteps - 1 ? stepLineUndoneWidget(i) : Container()
               ],
             )
           : selectedStep > i
               ? Column(
                   children: <Widget>[
                     stepDoneWidget(),
-                    i < nbSteps - 1 ? stepLineDoneWidget() : Container(),
+                    i < nbSteps - 1 ? stepLineDoneWidget(i) : Container(),
                   ],
                 )
               : Column(
                   children: <Widget>[
                     stepUnselectedWidget(),
-                    i != nbSteps - 1 ? stepLineUndoneWidget() : Container()
+                    i != nbSteps - 1 ? stepLineUndoneWidget(i) : Container()
                   ],
                 ));
     }
@@ -164,17 +166,36 @@ class StepsIndicator extends StatelessWidget {
           );
   }
 
-  Widget stepLineDoneWidget() {
+  Widget stepLineDoneWidget(int i) {
     return Container(
-        height: isHorizontal ? lineThickness : lineLength,
-        width: isHorizontal ? lineLength : lineThickness,
+        height: isHorizontal ? lineThickness : getLineLength(i),
+        width: isHorizontal ? getLineLength(i) : lineThickness,
         color: doneLineColor);
   }
 
-  Widget stepLineUndoneWidget() {
+  Widget stepLineUndoneWidget(int i) {
     return Container(
-        height: isHorizontal ? lineThickness : lineLength,
-        width: isHorizontal ? lineLength : lineThickness,
+        height: isHorizontal ? lineThickness : getLineLength(i),
+        width: isHorizontal ? getLineLength(i) : lineThickness,
         color: undoneLineColor);
   }
+
+  double getLineLength(int i) {
+    var nbStep = i + 1;
+    if (lineLengthCustomStep != null && lineLengthCustomStep.length > 0) {
+      if (lineLengthCustomStep.any((it) => (it.nbStep - 1) == nbStep)) {
+        return lineLengthCustomStep
+            .firstWhere((it) => (it.nbStep - 1) == nbStep)
+            .lenght;
+      }
+    }
+    return lineLength;
+  }
+}
+
+class StepsIndicatorCustomLine {
+  final int nbStep;
+  final double lenght;
+
+  StepsIndicatorCustomLine({this.nbStep, this.lenght});
 }


### PR DESCRIPTION
In my project  had the need to customize the line length between steps. The package did not allow to customize the length of one specific step, always inputted the steps (circles) in the middle of the line. I created a function to put the lenght of specific step informed in constructor of the widget ** StepsIndicator **, to do that was created a class named ** StepsIndicatorCustomLine **, below an example of use:

`      StepsIndicatorCustom(
                  nbSteps: 3,
                  isHorizontal: false,
                  doneStepSize: 20,
                  unselectedStepSize: 20,
                  selectedStepSize: 20,
                  lineLength: 145,
                  lineThickness: 4,
                  selectedStep: 1,
                  lineLengthCustomStep: [StepsIndicatorCustomLine(nbStep:2, lenght: 35)]
                )`

Now you can customize the length to each steps in StepsIndicator widg
![Screen Shot 2020-06-15 at 17 09 14](https://user-images.githubusercontent.com/25160500/84705561-f8c2dd80-af31-11ea-8a65-f967db9fc41c.png)

